### PR TITLE
Error from command [p]automodset show

### DIFF
--- a/automod/settings.py
+++ b/automod/settings.py
@@ -254,7 +254,7 @@ class Settings:
             if rulename not in self.rules_map:
                 nl = "\n"
                 return await ctx.send(
-                    await error_message(
+                    error_message(
                         f"`{rulename}` is not a valid rule. The options are:\n\n"
                         f"{nl.join('• `{0}`'.format(w) for w in self.rules_map)}"
                     )


### PR DESCRIPTION
Removed await to fix your error.  Cheers

**Log**
```
  File "/root/eveDevCogs/cogs/CogManager/cogs/automod/settings.py", line 257, in show_all_settings
    await error_message(
TypeError: object str can't be used in 'await' expression
```